### PR TITLE
Treat the contents of .extra files as JSON since we switched to that format a while ago

### DIFF
--- a/phc_symbolize.py
+++ b/phc_symbolize.py
@@ -456,7 +456,17 @@ def main(argv=None):
         print("")
 
         for entry in stack:
-            print("#%s    %s (%s)" % (entry["frame"], entry["function"], entry["module"]))
+            frame = "???"
+            if "frame" in entry:
+                frame = entry["frame"]
+            function = "???"
+            if "function" in entry:
+                function = entry["function"]
+            module = "???"
+            if "module" in entry:
+                module = entry["module"]
+
+            print("#%s    %s (%s)" % (frame, function, module))
 
     if symbol_server_response:
         stacks = symbol_server_response["results"][0]["stacks"]

--- a/phc_symbolize.py
+++ b/phc_symbolize.py
@@ -167,21 +167,20 @@ def retrieve_file_line_data(symbol_entry, reladdr):
 
 def read_extra_file(extra_file):
     def make_stack_array(line):
-        return [int(x) for x in line.rstrip().split(sep="=")[1].split(",")]
+        return [int(x) for x in line.rstrip().split(",")]
 
     alloc_stack = None
     free_stack = None
     modules = None
 
     with open(extra_file, 'r') as extra_file_fd:
-        for line in extra_file_fd:
-            if line.startswith("PHCAllocStack"):
-                alloc_stack = make_stack_array(line)
-            elif line.startswith("PHCFreeStack"):
-                free_stack = make_stack_array(line)
-            elif line.startswith("StackTraces"):
-                obj = json.loads(line.split(sep="=")[1])
-                modules = obj["modules"]
+        data = json.load(extra_file_fd)
+        if "PHCAllocStack" in data:
+            alloc_stack = make_stack_array(data["PHCAllocStack"])
+        elif "PHCFreeStack" in data:
+            free_stack = make_stack_array(data["PHCFreeStack"])
+        elif "StackTraces" in data:
+            modules = json.loads(data["StackTraces"])["modules"]
 
     module_memory_map = {}
 

--- a/phc_symbolize.py
+++ b/phc_symbolize.py
@@ -361,7 +361,7 @@ def main(argv=None):
 
                     request["stacks"].append(stacks)
 
-            symbol_server_response = requests.post("https://symbols.mozilla.org/symbolicate/v5", json=request).json()
+            symbol_server_response = requests.post("https://symbolication.services.mozilla.com/symbolicate/v5", json=request).json()
             if "results" not in symbol_server_response:
                 print("Error in server response: %s" % symbol_server_response, file=sys.stderr)
                 return 2


### PR DESCRIPTION
This fixes issue #4

I've also rolled in a couple smaller fixes:
- Use the new symbol server
- Don't error out if one of the stack entries did not have a symbol associated with it